### PR TITLE
fix incomplete save files not loading + minor refactor

### DIFF
--- a/SonsOfTheForestCompanionRescue/Form1.cs
+++ b/SonsOfTheForestCompanionRescue/Form1.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using System.Diagnostics;
 using SonsOfTheForest.Saves;
@@ -19,6 +20,7 @@ namespace SonsOfTheForestCompanionRescue
         private int _currentEditedSaveIndex = -1;
 
         private bool _isDirty = false;
+        private bool _isUpdatingUI = false;
         private NPC _kelvin;
         private NPC _virginia;
 
@@ -87,19 +89,32 @@ namespace SonsOfTheForestCompanionRescue
             }
         }
 
-        private void ResurrectNPC(int npcID)
+        private void ResurrectNPC(NPC npc)
         {
+            if (npc == null)
+            {
+                return;
+            }
+
+            var npcID = npc.TypeID;
             var gameSaveData = _currentlyEditedSave.Contents["SaveData.json"];
             //Edit KillStatsList JArray to remove the kill
             var killStatsList = (JArray)gameSaveData.SelectToken("Data.VailWorldSim.KillStatsList");
             var npcKillStat = killStatsList.FirstOrDefault(o => (int)o["TypeId"] == npcID);
-            npcKillStat["PlayerKilled"] = 0;
+            if (npcKillStat != null)
+            {
+                npcKillStat["PlayerKilled"] = 0;
+            }
 
             //Edit the companion data
             var actorList = (JArray)gameSaveData.SelectToken("Data.VailWorldSim.Actors");
             var companionData = actorList.FirstOrDefault(o => (int)o["TypeId"] == npcID);
-            companionData["Stats"]["Health"] = 100;
-            companionData["State"] = 2;
+            if (companionData != null)
+            {
+                // Update the existing token so NPC.Health (a cached JValue reference) stays in sync.
+                npc.Health.Value = 100d;
+                companionData["State"] = 2;
+            }
 
             //Edit the game's state save to remove kill flags if applicable
             //GameStateSaveData.json -> Data.GameState
@@ -117,6 +132,27 @@ namespace SonsOfTheForestCompanionRescue
             }
             UpdateUIValues();
             _isDirty = true;
+        }
+
+        private void ReloadCurrentSave()
+        {
+            if (_currentlyEditedSave == null)
+            {
+                return;
+            }
+
+            var save = new GameSave(_currentlyEditedSave.DirPath);
+            _currentlyEditedSave = save;
+            selectedSavePathTextBox.Text = save.DirPath;
+            selectedSaveType.Text = save.Type.ToString();
+            selectedSaveDateLabel.Text = save.SaveTime.ToString();
+            selectedSaveThumbnailPictureBox.ImageLocation = save.DirPath + "\\SaveDataThumbnail.png";
+
+            _kelvin = new NPC(_kelvinInternalTypeID, save);
+            _virginia = new NPC(_virginiaInternalTypeID, save);
+
+            UpdateUIValues();
+            _isDirty = false;
         }
 
         private void gameSavesComboBox_SelectedIndexChanged(object sender, EventArgs e)
@@ -157,33 +193,41 @@ namespace SonsOfTheForestCompanionRescue
 
         private void UpdateUIValues()
         {
-            kelvinStatusLabel.Text = _kelvin.Alive ? "Alive" : "Deceased";
-            if (_kelvin.Alive)
+            _isUpdatingUI = true;
+            try
             {
-                kelvinStatusLabel.ForeColor = Color.Green;
+                kelvinStatusLabel.Text = _kelvin.Alive ? "Alive" : "Deceased";
+                if (_kelvin.Alive)
+                {
+                    kelvinStatusLabel.ForeColor = Color.Green;
+                }
+                else
+                {
+                    kelvinStatusLabel.ForeColor = Color.Red;
+                }
+                kelvinHealthNumeric.Value = (decimal)_kelvin.Health;
+                kelvinPosXNumeric.Value = (decimal)_kelvin.X;
+                kelvinPosYNumeric.Value = (decimal)_kelvin.Y;
+                kelvinPosZNumeric.Value = (decimal)_kelvin.Z;
+                //
+                virginiaStatusLabel.Text = _virginia.Alive ? "Alive" : "Deceased";
+                if (_virginia.Alive)
+                {
+                    virginiaStatusLabel.ForeColor = Color.Green;
+                }
+                else
+                {
+                    virginiaStatusLabel.ForeColor = Color.Red;
+                }
+                virginiaHealthNumeric.Value = (decimal)_virginia.Health;
+                virginiaPosXNumeric.Value = (decimal)_virginia.X;
+                virginiaPosYNumeric.Value = (decimal)_virginia.Y;
+                virginiaPosZNumeric.Value = (decimal)_virginia.Z;
             }
-            else
+            finally
             {
-                kelvinStatusLabel.ForeColor = Color.Red;
+                _isUpdatingUI = false;
             }
-            kelvinHealthNumeric.Value = (decimal)_kelvin.Health;
-            kelvinPosXNumeric.Value = (decimal)_kelvin.X;
-            kelvinPosYNumeric.Value = (decimal)_kelvin.Y;
-            kelvinPosZNumeric.Value = (decimal)_kelvin.Z;
-            //
-            virginiaStatusLabel.Text = _virginia.Alive ? "Alive" : "Deceased";
-            if (_virginia.Alive)
-            {
-                virginiaStatusLabel.ForeColor = Color.Green;
-            }
-            else
-            {
-                virginiaStatusLabel.ForeColor = Color.Red;
-            }
-            virginiaHealthNumeric.Value = (decimal)_virginia.Health;
-            virginiaPosXNumeric.Value = (decimal)_virginia.X;
-            virginiaPosYNumeric.Value = (decimal)_virginia.Y;
-            virginiaPosZNumeric.Value = (decimal)_virginia.Z;
         }
 
         private void MoveNPCToLocation(NPC npc, double x, double y, double z)
@@ -195,14 +239,35 @@ namespace SonsOfTheForestCompanionRescue
             _isDirty = true;
         }
 
-        private void saveChangesButton_Click(object sender, EventArgs e)
+        private async void saveChangesButton_Click(object sender, EventArgs e)
         {
-            _currentlyEditedSave.WriteChanges();
-            _isDirty = false;
+            if (_currentlyEditedSave == null)
+            {
+                return;
+            }
+
+            saveChangesButton.Enabled = false;
+            try
+            {
+                _currentlyEditedSave.WriteChanges();
+                _isDirty = false;
+
+                // Give the OS a moment to finish writing/closing the zip before re-opening it.
+                await Task.Delay(150);
+                ReloadCurrentSave();
+            }
+            finally
+            {
+                saveChangesButton.Enabled = true;
+            }
         }
 
         private void kelvinHealthNumeric_ValueChanged(object sender, EventArgs e)
         {
+            if (_isUpdatingUI)
+            {
+                return;
+            }
             _kelvin.Health.Value = (double)kelvinHealthNumeric.Value;
             _isDirty = true;
         }
@@ -243,18 +308,22 @@ namespace SonsOfTheForestCompanionRescue
 
         private void virginiaHealthNumeric_ValueChanged(object sender, EventArgs e)
         {
+            if (_isUpdatingUI)
+            {
+                return;
+            }
             _virginia.Health.Value = (double)virginiaHealthNumeric.Value;
             _isDirty = true;
         }
 
         private void kelvinResurrectButton_Click(object sender, EventArgs e)
         {
-            ResurrectNPC(_kelvinInternalTypeID);
+            ResurrectNPC(_kelvin);
         }
 
         private void virginiaResurrectButton_Click(object sender, EventArgs e)
         {
-            ResurrectNPC(_virginiaInternalTypeID);
+            ResurrectNPC(_virginia);
         }
 
         private void repoLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/SonsOfTheForestCompanionRescue/NPC.cs
+++ b/SonsOfTheForestCompanionRescue/NPC.cs
@@ -21,7 +21,7 @@ namespace SonsOfTheForestCompanionRescue
         {
             get
             {
-                return (int)Health > 0;
+                return (Health?.Value<double?>() ?? 0d) > 0d;
             }
         }
         public JValue Health { get; private set; }
@@ -40,10 +40,39 @@ namespace SonsOfTheForestCompanionRescue
             {
                 throw new Exception($"No NPC with {npcTypeId} was found.");
             }
-            Health = (JValue)Data["Stats"]["Health"];
-            X = (JValue)Data["Position"]["x"];
-            Y = (JValue)Data["Position"]["y"];
-            Z = (JValue)Data["Position"]["z"];
+
+            // Some save versions omit certain fields; ensure they're present so the UI can read/edit safely.
+            var dataObj = Data as JObject;
+            if (dataObj == null)
+            {
+                throw new Exception($"NPC data for {npcTypeId} was not an object.");
+            }
+
+            var statsObj = dataObj["Stats"] as JObject;
+            if (statsObj == null)
+            {
+                statsObj = new JObject();
+                dataObj["Stats"] = statsObj;
+            }
+            if (statsObj["Health"] == null || statsObj["Health"].Type == JTokenType.Null)
+            {
+                statsObj["Health"] = 0d;
+            }
+            Health = (JValue)statsObj["Health"];
+
+            var posObj = dataObj["Position"] as JObject;
+            if (posObj == null)
+            {
+                posObj = new JObject();
+                dataObj["Position"] = posObj;
+            }
+            if (posObj["x"] == null || posObj["x"].Type == JTokenType.Null) posObj["x"] = 0d;
+            if (posObj["y"] == null || posObj["y"].Type == JTokenType.Null) posObj["y"] = 0d;
+            if (posObj["z"] == null || posObj["z"].Type == JTokenType.Null) posObj["z"] = 0d;
+
+            X = (JValue)posObj["x"];
+            Y = (JValue)posObj["y"];
+            Z = (JValue)posObj["z"];
         }
     }
 }

--- a/SonsOfTheForestCompanionRescue/SonsOfTheForestCompanionRescue.csproj
+++ b/SonsOfTheForestCompanionRescue/SonsOfTheForestCompanionRescue.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
I also updated the .net to 8 but this was just cause I didn't have 6 and 8 is now in LTS

### TLDR:

- Added a bunch of fallback values, so if the savefile doesn't currently contain the given values it won't error 
- Using the already existing `NPC` instead of their int when referring to a npc
- OS writes are now async to not freeze UI
- Force UI updates and freeze on writes (finer control) 

### Commits:
[fix save file issues](https://github.com/Xerren09/Sons-Of-The-Forest-Companion-Rescue-Tool/commit/e1ed075382256129d8b7a090ebebb9d447cddc74)
[smol refactor n cleanup](https://github.com/Xerren09/Sons-Of-The-Forest-Companion-Rescue-Tool/commit/fbe8b2f41f44ef93df23e33cad7a1be39a955fb8)